### PR TITLE
fix: snippets keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ The extension provides shortcuts for toggling/shuffling checkbox state. The shor
 - `u` - Unchecked (`[ ] `)
 - `a`/`@` - Ongoing (`[@] `)
 - `o`/`~` - Obsolete (`[~] `)
-- `x` - Unchecked (`[x] `)
+- `x` - Checked (`[x] `)

--- a/snippets.json
+++ b/snippets.json
@@ -1,6 +1,6 @@
 {
     "Unchecked Item (u)": {
-        "prefix": "o",
+        "prefix": "u",
         "body": ["[ ] $1"],
         "description": "Unchecked item"
     },


### PR DESCRIPTION
There's a typo in the README as well as in the snippets.json file.

Merging this PR fixes issue #1 
